### PR TITLE
Add support and example for vendor SPARQL endpoint

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -39,6 +39,22 @@ defmodule Acl.UserGroups.Config do
       }
   end
 
+  defp access_for_vendor_api() do
+    %AccessByQuery{
+      vars: ["vendor_id", "session_group"],
+      query: sparql_query_for_access_vendor_api()
+    }
+  end
+
+  defp sparql_query_for_access_vendor_api() do
+    " PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      SELECT DISTINCT ?vendor_id ?session_group WHERE {
+        <SESSION_ID> muAccount:canActOnBehalfOf/mu:uuid ?session_group;
+                     muAccount:account/mu:uuid ?vendor_id.
+      } "
+  end
+
   def user_groups do
     # These elements are walked from top to bottom.  Each of them may
     # alter the quads to which the current query applies.  Quads are
@@ -91,6 +107,20 @@ defmodule Acl.UserGroups.Config do
                         "http://lblod.data.gift/services/Service",
                         "http://redpencil.data.gift/vocabularies/tasks/Operation",
                         "http://vocab.deri.ie/cogs#ExecutionStatus"
+                      ] } } ] },
+
+      # // TOEZICHT VENDOR API
+      %GroupSpec{
+        name: "o-vendor-api-r",
+        useage: [:read],
+        access: access_for_vendor_api(),
+        graphs: [ %GraphSpec{
+                    graph: "http://mu.semte.ch/graphs/vendors/",
+                    constraint: %ResourceConstraint{
+                      resource_types: [
+                        "http://rdf.myexperiment.org/ontologies/base/Submission",
+                        "http://mu.semte.ch/vocabularies/ext/SubmissionDocument",
+                        "http://lblod.data.gift/vocabularies/automatische-melding/FormData",
                       ] } } ] },
 
       # // VENDOR MANAGEMENT

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -219,4 +219,21 @@ export default [
       ignoreFromSelf: true
     }
   },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status'
+      }
+    },
+    callback: {
+      url: 'http://vendor-data-distribution/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true
+    }
+  },
 ];

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -287,6 +287,31 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://person-uri-for-social-security-number/"
   end
 
+  #################################################################
+  # Vendor Login for SPARQL endpoint
+  #################################################################
+
+  post "/login/*path" do
+    Proxy.forward conn, path, "http://vendor-login/sessions"
+  end
+
+  delete "/logout" do
+    Proxy.forward conn, [], "http://vendor-login/sessions/current"
+  end
+
+  #################################################################
+  # Vendor SPARQL endpoint
+  #################################################################
+
+  # Not only POST. SPARQL via GET is also allowed, but need to find a way to also forward URL parameters.
+  match "/sparql" do
+    Proxy.forward conn, [], "http://sparql-authorization-wrapper/sparql"
+  end
+
+  #################################################################
+  # Catch all that is left
+  #################################################################
+
   match _ do
     send_resp( conn, 404, "Route not found.  See config/dispatcher.ex" )
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -294,11 +294,11 @@ defmodule Dispatcher do
   # Vendor Login for SPARQL endpoint
   #################################################################
 
-  post "/login/*path" do
+  post "/vendor/login/*path" do
     Proxy.forward conn, path, "http://vendor-login/sessions"
   end
 
-  delete "/logout" do
+  delete "/vendor/logout" do
     Proxy.forward conn, [], "http://vendor-login/sessions/current"
   end
 
@@ -307,7 +307,7 @@ defmodule Dispatcher do
   #################################################################
 
   # Not only POST. SPARQL via GET is also allowed.
-  match "/sparql" do
+  match "/vendor/sparql" do
     Proxy.forward conn, [], "http://sparql-authorization-wrapper/sparql"
   end
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -218,6 +218,7 @@ defmodule Dispatcher do
   #################################################################
   # automatic submission
   #################################################################
+
   match "/melding/*path" do
     Proxy.forward conn, path, "http://automatic-submission/melding"
   end
@@ -225,9 +226,11 @@ defmodule Dispatcher do
   #################################################################
   # verify submission (to be removed)
   #################################################################
+
   get "/verify/bestuurseenheid/*path" do
     Proxy.forward conn, path, "http://verify-submission/bestuurseenheid"
   end
+
   get "/verify/inzending/*path" do
     Proxy.forward conn, path, "http://verify-submission/inzending"
   end
@@ -303,9 +306,19 @@ defmodule Dispatcher do
   # Vendor SPARQL endpoint
   #################################################################
 
-  # Not only POST. SPARQL via GET is also allowed, but need to find a way to also forward URL parameters.
+  # Not only POST. SPARQL via GET is also allowed.
   match "/sparql" do
     Proxy.forward conn, [], "http://sparql-authorization-wrapper/sparql"
+  end
+
+  #################################################################
+  # Vendor data distribution tests
+  #################################################################
+
+  # The service protects this route. If not running in development, this route
+  # in unavaliable. There should be no risk in exposing this route.
+  get "/vendor-data-distribution/test" do
+    Proxy.forward conn, [], "http://vendor-data-distribution/test"
   end
 
   #################################################################

--- a/config/sparql-authorization-wrapper/filter.js
+++ b/config/sparql-authorization-wrapper/filter.js
@@ -15,7 +15,7 @@ export async function isAuthorized(sessionUri) {
     PREFIX oslc: <http://open-services.net/ns/core#>
     PREFIX dct: <http://purl.org/dc/terms/>
 
-    SELECT ?uuid ?created ?account {
+    SELECT DISTINCT ?uuid ?created ?account {
       GRAPH ?g {
         ${mu.sparqlEscapeUri(sessionUri)}
           a session:Session ;

--- a/config/sparql-authorization-wrapper/filter.js
+++ b/config/sparql-authorization-wrapper/filter.js
@@ -1,0 +1,32 @@
+import * as mu from 'mu';
+import * as mas from '@lblod/mu-auth-sudo';
+
+export async function isAuthorized(sessionUri) {
+  const checkSessionQuery = `
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+    PREFIX wotSec: <https://www.w3.org/2019/wot/security#>
+    PREFIX lblodAuth: <http://lblod.data.gift/vocabularies/authentication/>
+    PREFIX pav: <http://purl.org/pav/>
+    PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+    PREFIX oslc: <http://open-services.net/ns/core#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+
+    SELECT ?uuid ?created ?account {
+      GRAPH ?g {
+        ${mu.sparqlEscapeUri(sessionUri)}
+          a session:Session ;
+          mu:uuid ?uuid ;
+          dct:created ?created ;
+          muAccount:account ?account .
+      }
+    }
+  `;
+  const response = await mas.querySudo(checkSessionQuery);
+  // We want exactly one result, only one session should exist at a certain time.
+  const exists = response.results?.bindings?.length === 1;
+  return exists;
+}

--- a/config/sparql-authorization-wrapper/filter.js
+++ b/config/sparql-authorization-wrapper/filter.js
@@ -22,7 +22,7 @@ export async function isAuthorized(sessionUri) {
           mu:uuid ?uuid ;
           dct:created ?created ;
           muAccount:account ?account ;
-         muAccount:canActOnBehalfOf ?org.
+          muAccount:canActOnBehalfOf ?org .
       }
     }
   `;

--- a/config/sparql-authorization-wrapper/filter.js
+++ b/config/sparql-authorization-wrapper/filter.js
@@ -21,7 +21,8 @@ export async function isAuthorized(sessionUri) {
           a session:Session ;
           mu:uuid ?uuid ;
           dct:created ?created ;
-          muAccount:account ?account .
+          muAccount:account ?account ;
+         muAccount:canActOnBehalfOf ?org.
       }
     }
   `;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,6 +56,9 @@ services:
     environment:
       DEFAULT_SPARQL_ENDPOINT: "http://virtuoso/"
       ENABLE_ENDPOINT_SELECTOR: "true"
-
   job-controller:
+    restart: "no"
+  vendor-login:
+    restart: "no"
+  sparql-authorization-wrapper:
     restart: "no"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -62,3 +62,5 @@ services:
     restart: "no"
   sparql-authorization-wrapper:
     restart: "no"
+  vendor-data-distribution:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,3 +199,14 @@ services:
       - "logging=true"
     restart: "always"
     logging: *default-logging
+
+##############################################################################
+# Vendor endpoint
+##############################################################################
+
+  vendor-login:
+    image: lblod/vendor-login-service:latest
+  sparql-authorization-wrapper:
+    image: lblod/sparql-authorization-wrapper-service:latest
+    volumes:
+      - ./config/sparql-authorization-wrapper:/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,10 +205,10 @@ services:
 ##############################################################################
 
   vendor-login:
-    image: lblod/vendor-login-service:latest
+    image: lblod/vendor-login-service:1.0.0
   sparql-authorization-wrapper:
-    image: lblod/sparql-authorization-wrapper-service:latest
+    image: lblod/sparql-authorization-wrapper-service:1.0.0
     volumes:
       - ./config/sparql-authorization-wrapper:/config
   vendor-data-distribution:
-    image: lblod/vendor-data-distribution-service:latest
+    image: lblod/vendor-data-distribution-service:1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,3 +210,5 @@ services:
     image: lblod/sparql-authorization-wrapper-service:latest
     volumes:
       - ./config/sparql-authorization-wrapper:/config
+  vendor-data-distribution:
+    image: lblod/vendor-data-distribution-service:latest


### PR DESCRIPTION
Added the `vendor-login-service`, the `sparql-authorization-wrapper-service`, the `vendor-data-distribution-service`, rules for those in the dispatcher's config, the `delta-notifier`'s config, `mu-authorization`'s config and an example filter rule for the wrapper.