### PR TITLE
Optimisation: source graphs for VDDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.50.1 (2026-05-28)
+
+- New version of the `vendor-data-distribution-service` [DL-7378] for source
+  graph selection
+
+### Deploy instructions
+
+**For the new VDDS:**
+
+```
+drc up -d vendor-data-distribution
+```
+
+You could potentially start a healing process:
+
+```
+drc exec vendor-data-distribution-service curl -X POST 'http://localhost/heal'
+```
+
 ## v1.50.0 (2026-03-30)
 
 - New version of the `vendor-data-distribution-service` [DL-7231]

--- a/config/vendor-data/model.ttl
+++ b/config/vendor-data/model.ttl
@@ -49,6 +49,7 @@ meb:Submission
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 ext:SubmissionDocument
@@ -105,6 +106,7 @@ eli:has_part
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 osc:Error
@@ -139,6 +141,7 @@ task:error
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 schema:Conversation
@@ -210,6 +213,7 @@ nie:dataSource
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 <RelConversationMessageKaliope>
@@ -246,6 +250,7 @@ nie:dataSource
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 <RelConversationMessageLoket>
@@ -283,6 +288,7 @@ nie:dataSource
         mu:uuid ?organisationUuid .
     }
   """ ;
+  vdds:sourceGraphTemplate "http://mu.semte.ch/graphs/organizations/${organisationUuid}/LoketLB-toezichtGebruiker" ;
   vdds:targetGraphTemplate "http://mu.semte.ch/graphs/vendors/${vendorUuid}/${organisationUuid}" .
 
 <RelConversationMessageLoketControle>

--- a/config/vendor-data/model.ttl
+++ b/config/vendor-data/model.ttl
@@ -36,7 +36,7 @@
 
 meb:Submission
   rdf:type vdds:Class ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}
@@ -92,7 +92,7 @@ eli:has_part
       adms:status <http://redpencil.data.gift/id/concept/JobStatus/failed> ;
       task:operation <http://lblod.data.gift/id/jobs/concept/JobOperation/harvestBericht> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}
@@ -126,7 +126,7 @@ task:error
       adms:status <http://redpencil.data.gift/id/concept/JobStatus/success> ;
       task:operation <http://lblod.data.gift/id/jobs/concept/JobOperation/harvestBericht> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}
@@ -197,7 +197,7 @@ nie:dataSource
     ${subject}
       adms:status <http://data.lblod.info/id/status/berichtencentrum/sync-with-kalliope/delivered/confirmed> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject} schema:recipient ?organisation .
@@ -234,7 +234,7 @@ nie:dataSource
     ${subject}
       ext:creator <https://github.com/lblod/frontend-loket> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}
@@ -271,7 +271,7 @@ nie:dataSource
       ext:creator <https://github.com/lblod/frontend-loket> ;
       schema:sender <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> .
   """ ;
-  vdds:targetGraphQuery """
+  vdds:graphQuery """
     SELECT DISTINCT ?organisationUuid ?vendorUuid
     WHERE {
       ${subject}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,7 +254,7 @@ services:
     volumes:
       - ./config/sparql-authorization-wrapper:/config
   vendor-data-distribution:
-    image: lblod/vendor-data-distribution-service:2.0.0
+    image: lblod/vendor-data-distribution-service:2.2.0
     environment:
       LOGLEVEL: "error"
       WRITE_ERRORS: "true"


### PR DESCRIPTION
Part of **[DL-7378]**

This PR makes source data selection more careful. This could make the VDDS slightly more efficient, but mostly more correct as we are not just selecting from the whole triplestore, but rather from the specific organisation graphs that hold the data for that vendor.

In the past, the VDDS could copy data from any organisation (including vendor graphs for those organisations). Normally this is no problem, because Submission data is always properly contained within one organisation. Therefore this optimisation might be redundant, but can still be a good thing to have.