### PR TITLE
Add restart and logging labels

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,10 +249,18 @@ services:
 ##############################################################################
   vendor-login:
     image: lblod/vendor-login-service:1.1.0
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   sparql-authorization-wrapper:
     image: lblod/sparql-authorization-wrapper-service:1.1.0
     volumes:
       - ./config/sparql-authorization-wrapper:/config
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   vendor-data-distribution:
     image: lblod/vendor-data-distribution-service:2.2.0
     environment:


### PR DESCRIPTION
These were missing on the app which means a system reboot would not start up these services.  The previous setup also did not explicit the logging.